### PR TITLE
[Spring 경로 조회 - 2단계] 케이(김태현) 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 	// spring
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// log
 	implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'

--- a/src/main/java/wooteco/subway/dao/JdbcLineDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcLineDao.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 @Repository
 public class JdbcLineDao implements LineDao {
 
-    private static final RowMapper<Line> lineRowMapper = (resultSet, rowNum) -> new Line(
+    private static final RowMapper<Line> LINE_ROW_MAPPER = (resultSet, rowNum) -> new Line(
             resultSet.getLong("id"),
             resultSet.getString("name"),
             resultSet.getString("color"),
@@ -48,7 +48,7 @@ public class JdbcLineDao implements LineDao {
     public Optional<Line> findById(Long id) {
         final String sql = "select * from LINE where id = ?";
         try {
-            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, lineRowMapper, id));
+            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, LINE_ROW_MAPPER, id));
         } catch (EmptyResultDataAccessException e) {
             return Optional.empty();
         }
@@ -57,7 +57,7 @@ public class JdbcLineDao implements LineDao {
     @Override
     public List<Line> findAll() {
         final String sql = "select * from LINE";
-        return jdbcTemplate.query(sql, lineRowMapper);
+        return jdbcTemplate.query(sql, LINE_ROW_MAPPER);
     }
 
     @Override

--- a/src/main/java/wooteco/subway/dao/JdbcLineDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcLineDao.java
@@ -3,19 +3,20 @@ package wooteco.subway.dao;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.support.GeneratedKeyHolder;
-import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 import wooteco.subway.domain.Line;
 import wooteco.subway.dto.LineRequest;
 
-import java.sql.PreparedStatement;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Repository
 public class JdbcLineDao implements LineDao {
-
     private static final RowMapper<Line> LINE_ROW_MAPPER = (resultSet, rowNum) -> new Line(
             resultSet.getLong("id"),
             resultSet.getString("name"),
@@ -23,35 +24,40 @@ public class JdbcLineDao implements LineDao {
             resultSet.getInt("extraFare")
     );
 
-    private final JdbcTemplate jdbcTemplate;
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+    private final SimpleJdbcInsert simpleJdbcInsert;
 
     public JdbcLineDao(JdbcTemplate jdbcTemplate) {
-        this.jdbcTemplate = jdbcTemplate;
+        this.jdbcTemplate = new NamedParameterJdbcTemplate(jdbcTemplate);
+        this.simpleJdbcInsert = new SimpleJdbcInsert(jdbcTemplate)
+                .withTableName("LINE")
+                .usingGeneratedKeyColumns("id");
     }
 
     @Override
     public Long save(LineRequest lineRequest) {
-        final String sql = "insert into LINE (name, color, extraFare) values (?, ?, ?)";
-        final KeyHolder keyHolder = new GeneratedKeyHolder();
-        jdbcTemplate.update(connection -> {
-            PreparedStatement ps = connection.prepareStatement(sql, new String[]{"id"});
-            ps.setString(1, lineRequest.getName());
-            ps.setString(2, lineRequest.getColor());
-            ps.setInt(3, lineRequest.getExtraFare());
-            return ps;
-        }, keyHolder);
+        final SqlParameterSource sqlParameterSource =
+                new MapSqlParameterSource("name", lineRequest.getName())
+                        .addValue("color", lineRequest.getColor())
+                        .addValue("extraFare", lineRequest.getExtraFare());
 
-        return keyHolder.getKey().longValue();
+        return simpleJdbcInsert.executeAndReturnKey(sqlParameterSource).longValue();
     }
 
     @Override
     public Optional<Line> findById(Long id) {
-        final String sql = "select * from LINE where id = ?";
+        final String sql = "select * from LINE where id = :id";
         try {
-            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, LINE_ROW_MAPPER, id));
+            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, Map.of("id", id), LINE_ROW_MAPPER));
         } catch (EmptyResultDataAccessException e) {
             return Optional.empty();
         }
+    }
+
+    @Override
+    public List<Line> findByIds(List<Long> ids) {
+        final String sql = "select * from LINE where id in (:ids)";
+        return jdbcTemplate.query(sql, Map.of("ids", ids), LINE_ROW_MAPPER);
     }
 
     @Override
@@ -62,19 +68,26 @@ public class JdbcLineDao implements LineDao {
 
     @Override
     public boolean hasLine(String name) {
-        final String sql = "select exists (select * from LINE where name = ?)";
-        return jdbcTemplate.queryForObject(sql, Boolean.class, name);
+        final String sql = "select exists (select * from LINE where name = :name)";
+        return jdbcTemplate.queryForObject(sql, Map.of("name", name), Boolean.class);
     }
 
     @Override
     public void updateById(Long id, String name, String color, int extraFare) {
-        final String sql = "update LINE set name = ?, color = ?, extraFare = ? where id = ?";
-        jdbcTemplate.update(sql, name, color, extraFare, id);
+        final String sql = "update LINE set name = :name, color = :color, extraFare = :extraFare where id = :id";
+
+        final SqlParameterSource sqlParameterSource =
+                new MapSqlParameterSource("name", name)
+                        .addValue("color", color)
+                        .addValue("extraFare", extraFare)
+                        .addValue("id", id);
+
+        jdbcTemplate.update(sql, sqlParameterSource);
     }
 
     @Override
     public void deleteById(Long id) {
-        final String sql = "delete from LINE where id = ?";
-        jdbcTemplate.update(sql, id);
+        final String sql = "delete from LINE where id = :id";
+        jdbcTemplate.update(sql, Map.of("id", id));
     }
 }

--- a/src/main/java/wooteco/subway/dao/JdbcSectionDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcSectionDao.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 @Repository
 public class JdbcSectionDao implements SectionDao {
 
-    private static final RowMapper<Section> sectionRowMapper = (resultSet, rowNum) -> new Section(
+    private static final RowMapper<Section> SECTION_ROW_MAPPER = (resultSet, rowNum) -> new Section(
             resultSet.getLong("id"),
             resultSet.getLong("line_id"),
             resultSet.getLong("up_station_id"),
@@ -50,7 +50,7 @@ public class JdbcSectionDao implements SectionDao {
     public Optional<Section> findById(Long id) {
         final String sql = "select * from SECTION where id = ?";
         try {
-            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, sectionRowMapper, id));
+            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, SECTION_ROW_MAPPER, id));
         } catch (EmptyResultDataAccessException e) {
             return Optional.empty();
         }
@@ -59,20 +59,20 @@ public class JdbcSectionDao implements SectionDao {
     @Override
     public List<Section> findByLineId(Long lineId) {
         final String sql = "select * from SECTION where line_id = ?";
-        return jdbcTemplate.query(sql, sectionRowMapper, lineId);
+        return jdbcTemplate.query(sql, SECTION_ROW_MAPPER, lineId);
     }
 
     @Override
     public List<Section> findAll() {
         final String sql = "select * from SECTION";
-        return jdbcTemplate.query(sql, sectionRowMapper);
+        return jdbcTemplate.query(sql, SECTION_ROW_MAPPER);
     }
 
     @Override
     public Optional<Section> findByStationId(Long stationId) {
         final String sql = "select * from SECTION where (up_station_id = ? or down_station_id = ?)";
         try {
-            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, sectionRowMapper,
+            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, SECTION_ROW_MAPPER,
                     stationId, stationId));
         } catch (EmptyResultDataAccessException e) {
             return Optional.empty();
@@ -84,7 +84,7 @@ public class JdbcSectionDao implements SectionDao {
         final String sql = "select * from SECTION where (line_id = ? and up_station_id = ?) or" +
                 " (line_id = ? and down_station_id = ?)";
         try {
-            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, sectionRowMapper,
+            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, SECTION_ROW_MAPPER,
                     lineId, section.getUpStationId(), lineId, section.getDownStationId()));
         } catch (EmptyResultDataAccessException e) {
             return Optional.empty();
@@ -95,7 +95,7 @@ public class JdbcSectionDao implements SectionDao {
     public Optional<Section> findByUpStationId(Long lineId, Long upStationId) {
         final String sql = "select * from SECTION where line_id = ? and up_station_id = ?";
         try {
-            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, sectionRowMapper, lineId, upStationId));
+            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, SECTION_ROW_MAPPER, lineId, upStationId));
         } catch (EmptyResultDataAccessException e) {
             return Optional.empty();
         }
@@ -105,7 +105,7 @@ public class JdbcSectionDao implements SectionDao {
     public Optional<Section> findByDownStationId(Long lineId, Long downStationId) {
         final String sql = "select * from SECTION where line_id = ? and down_station_id = ?";
         try {
-            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, sectionRowMapper, lineId, downStationId));
+            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, SECTION_ROW_MAPPER, lineId, downStationId));
         } catch (EmptyResultDataAccessException e) {
             return Optional.empty();
         }

--- a/src/main/java/wooteco/subway/dao/JdbcStationDao.java
+++ b/src/main/java/wooteco/subway/dao/JdbcStationDao.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 @Repository
 public class JdbcStationDao implements StationDao {
 
-    private static final RowMapper<Station> stationRowMapper = (resultSet, rowNum) -> new Station(
+    private static final RowMapper<Station> STATION_ROW_MAPPER = (resultSet, rowNum) -> new Station(
             resultSet.getLong("id"),
             resultSet.getString("name")
     );
@@ -44,7 +44,7 @@ public class JdbcStationDao implements StationDao {
     public Optional<Station> findById(Long id) {
         final String sql = "select * from STATION where id = ?";
         try {
-            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, stationRowMapper, id));
+            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, STATION_ROW_MAPPER, id));
         } catch (EmptyResultDataAccessException e) {
             return Optional.empty();
         }
@@ -53,7 +53,7 @@ public class JdbcStationDao implements StationDao {
     @Override
     public List<Station> findAll() {
         final String sql = "select * from STATION";
-        return jdbcTemplate.query(sql, stationRowMapper);
+        return jdbcTemplate.query(sql, STATION_ROW_MAPPER);
     }
 
     @Override

--- a/src/main/java/wooteco/subway/dao/LineDao.java
+++ b/src/main/java/wooteco/subway/dao/LineDao.java
@@ -12,6 +12,8 @@ public interface LineDao {
 
     Optional<Line> findById(Long id);
 
+    List<Line> findByIds(List<Long> ids);
+
     List<Line> findAll();
 
     boolean hasLine(String name);

--- a/src/main/java/wooteco/subway/domain/AgeDiscountPolicy.java
+++ b/src/main/java/wooteco/subway/domain/AgeDiscountPolicy.java
@@ -1,0 +1,31 @@
+package wooteco.subway.domain;
+
+import java.util.Arrays;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public enum AgeDiscountPolicy {
+    BABY(age -> age >= 0 && age <= 5, discountFare -> 0),
+    CHILDREN(age -> age >= 6 && age <= 12, discountFare -> (int) ((discountFare - 350) * 0.5)),
+    TEENAGER(age -> age >= 13 && age <= 18, discountFare -> (int) ((discountFare - 350) * 0.2)),
+    ADULT(age -> age >= 19, discountFare -> 0);
+
+    private final Predicate<Integer> agePredicates;
+    private final Function<Integer, Integer> discountPolicy;
+
+    AgeDiscountPolicy(Predicate<Integer> agePredicates, Function<Integer, Integer> discountPolicy) {
+        this.agePredicates = agePredicates;
+        this.discountPolicy = discountPolicy;
+    }
+
+    public static AgeDiscountPolicy from(int age) {
+        return Arrays.stream(values())
+                .filter(it -> it.agePredicates.test(age))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("올바른 나이가 아닙니다."));
+    }
+
+    public int discountFare(int originFare) {
+        return discountPolicy.apply(originFare);
+    }
+}

--- a/src/main/java/wooteco/subway/domain/DiscountTypeByAge.java
+++ b/src/main/java/wooteco/subway/domain/DiscountTypeByAge.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-public enum AgeDiscountPolicy {
+public enum DiscountTypeByAge {
     BABY(age -> age >= 0 && age <= 5, discountFare -> 0),
     CHILDREN(age -> age >= 6 && age <= 12, discountFare -> (int) ((discountFare - 350) * 0.5)),
     TEENAGER(age -> age >= 13 && age <= 18, discountFare -> (int) ((discountFare - 350) * 0.2)),
@@ -13,12 +13,12 @@ public enum AgeDiscountPolicy {
     private final Predicate<Integer> agePredicates;
     private final Function<Integer, Integer> discountPolicy;
 
-    AgeDiscountPolicy(Predicate<Integer> agePredicates, Function<Integer, Integer> discountPolicy) {
+    DiscountTypeByAge(Predicate<Integer> agePredicates, Function<Integer, Integer> discountPolicy) {
         this.agePredicates = agePredicates;
         this.discountPolicy = discountPolicy;
     }
 
-    public static AgeDiscountPolicy from(int age) {
+    public static DiscountTypeByAge from(int age) {
         return Arrays.stream(values())
                 .filter(it -> it.agePredicates.test(age))
                 .findFirst()

--- a/src/main/java/wooteco/subway/domain/Fare.java
+++ b/src/main/java/wooteco/subway/domain/Fare.java
@@ -34,7 +34,7 @@ public class Fare {
     }
 
     private static int discountForYouth(int fare, int age) {
-        return AgeDiscountPolicy.from(age).discountFare(fare);
+        return DiscountTypeByAge.from(age).discountFare(fare);
     }
 
     public int getValue() {

--- a/src/main/java/wooteco/subway/domain/Fare.java
+++ b/src/main/java/wooteco/subway/domain/Fare.java
@@ -8,12 +8,6 @@ public class Fare {
     private static final int FARE_DISTANCE_LIMIT_FIRST = 10;
     private static final int FARE_DISTANCE_LIMIT_SECOND = 50;
 
-    private static final int CHILDREN_MIN_AGE = 6;
-    private static final int TEENAGER_MIN_AGE = 13;
-    private static final int ADULT_MIN_AGE = 19;
-    private static final double CHILDREN_DISCOUNT_RATIO = 0.5;
-    private static final double TEENAGER_DISCOUNT_RATIO = 0.2;
-
     private final int value;
 
     private Fare(int value) {
@@ -40,13 +34,7 @@ public class Fare {
     }
 
     private static int discountForYouth(int fare, int age) {
-        if (age >= CHILDREN_MIN_AGE && age < TEENAGER_MIN_AGE) {
-            return (int) ((fare - 350) * CHILDREN_DISCOUNT_RATIO);
-        }
-        if (age >= TEENAGER_MIN_AGE && age < ADULT_MIN_AGE) {
-            return (int) ((fare - 350) * TEENAGER_DISCOUNT_RATIO);
-        }
-        return 0;
+        return AgeDiscountPolicy.from(age).discountFare(fare);
     }
 
     public int getValue() {

--- a/src/main/java/wooteco/subway/domain/Fare.java
+++ b/src/main/java/wooteco/subway/domain/Fare.java
@@ -8,6 +8,12 @@ public class Fare {
     private static final int FARE_DISTANCE_LIMIT_FIRST = 10;
     private static final int FARE_DISTANCE_LIMIT_SECOND = 50;
 
+    private static final int CHILDREN_MIN_AGE = 6;
+    private static final int TEENAGER_MIN_AGE = 13;
+    private static final int ADULT_MIN_AGE = 19;
+    private static final double CHILDREN_DISCOUNT_RATIO = 0.5;
+    private static final double TEENAGER_DISCOUNT_RATIO = 0.2;
+
     private final int value;
 
     private Fare(int value) {
@@ -18,6 +24,11 @@ public class Fare {
         return new Fare(calculateFare(distance));
     }
 
+    public static Fare of(int distance, int extraFare, int age) {
+        final int fare = calculateFare(distance) + extraFare;
+        return new Fare(fare - discountForYouth(fare, age));
+    }
+
     private static int calculateFare(int distance) {
         if (distance <= FARE_DISTANCE_LIMIT_FIRST) {
             return DEFAULT_FARE;
@@ -26,6 +37,16 @@ public class Fare {
             return DEFAULT_FARE + (int) ((Math.ceil((distance - 11) / 5) + 1) * 100);
         }
         return DEFAULT_FARE_SECOND + (int) ((Math.ceil((distance - 51) / 8) + 1) * 100);
+    }
+
+    private static int discountForYouth(int fare, int age) {
+        if (age >= CHILDREN_MIN_AGE && age < TEENAGER_MIN_AGE) {
+            return (int) ((fare - 350) * CHILDREN_DISCOUNT_RATIO);
+        }
+        if (age >= TEENAGER_MIN_AGE && age < ADULT_MIN_AGE) {
+            return (int) ((fare - 350) * TEENAGER_DISCOUNT_RATIO);
+        }
+        return 0;
     }
 
     public int getValue() {

--- a/src/main/java/wooteco/subway/domain/Line.java
+++ b/src/main/java/wooteco/subway/domain/Line.java
@@ -24,6 +24,10 @@ public class Line {
         this(null, name, color, DEFAULT_EXTRA_FARE, Collections.emptyList());
     }
 
+    public Line(String name, String color, int extraFare) {
+        this(null, name, color, extraFare, Collections.emptyList());
+    }
+
     public Line(Long id, String name, String color, int extraFare) {
         this(id, name, color, extraFare, Collections.emptyList());
     }

--- a/src/main/java/wooteco/subway/domain/Line.java
+++ b/src/main/java/wooteco/subway/domain/Line.java
@@ -13,6 +13,7 @@ public class Line {
     private final Sections sections;
 
     public Line(Long id, String name, String color, int extraFare, List<Section> sections) {
+        validateLine(name, color);
         this.id = id;
         this.name = name;
         this.color = color;
@@ -20,20 +21,29 @@ public class Line {
         this.sections = new Sections(sections);
     }
 
-    public Line(String name, String color) {
-        this(null, name, color, DEFAULT_EXTRA_FARE, Collections.emptyList());
-    }
-
-    public Line(String name, String color, int extraFare) {
-        this(null, name, color, extraFare, Collections.emptyList());
+    public Line(Long id, String name, String color, int extraFare, Section section) {
+        this(id, name, color, extraFare, List.of(section));
     }
 
     public Line(Long id, String name, String color, int extraFare) {
         this(id, name, color, extraFare, Collections.emptyList());
     }
 
-    public Line(Long id, String name, String color, int extraFare, Section section) {
-        this(id, name, color, extraFare, List.of(section));
+    public Line(String name, String color, int extraFare) {
+        this(null, name, color, extraFare, Collections.emptyList());
+    }
+
+    public Line(String name, String color) {
+        this(null, name, color, DEFAULT_EXTRA_FARE, Collections.emptyList());
+    }
+
+    private void validateLine(String name, String color) {
+        if (name.isBlank()) {
+            throw new IllegalArgumentException("이름은 빈 값일 수 없습니다.");
+        }
+        if (color.isBlank()) {
+            throw new IllegalArgumentException("색상은 빈 값일 수 없습니다.");
+        }
     }
 
     public void addSection(Section section) {

--- a/src/main/java/wooteco/subway/domain/Path.java
+++ b/src/main/java/wooteco/subway/domain/Path.java
@@ -4,12 +4,12 @@ import java.util.List;
 
 public class Path {
     private final List<Station> stations;
-    private final List<Long> lineIds;
+    private final List<Long> includeLineIds;
     private final int distance;
 
-    public Path(List<Station> stations, List<Long> lineIds, int distance) {
+    public Path(List<Station> stations, List<Long> includeLineIds, int distance) {
         this.stations = stations;
-        this.lineIds = lineIds;
+        this.includeLineIds = includeLineIds;
         this.distance = distance;
     }
 
@@ -17,8 +17,8 @@ public class Path {
         return stations;
     }
 
-    public List<Long> getLineIds() {
-        return lineIds;
+    public List<Long> getIncludeLineIds() {
+        return includeLineIds;
     }
 
     public int getDistance() {

--- a/src/main/java/wooteco/subway/domain/Path.java
+++ b/src/main/java/wooteco/subway/domain/Path.java
@@ -1,0 +1,27 @@
+package wooteco.subway.domain;
+
+import java.util.List;
+
+public class Path {
+    private final List<Station> stations;
+    private final List<Long> lineIds;
+    private final int distance;
+
+    public Path(List<Station> stations, List<Long> lineIds, int distance) {
+        this.stations = stations;
+        this.lineIds = lineIds;
+        this.distance = distance;
+    }
+
+    public List<Station> getStations() {
+        return stations;
+    }
+
+    public List<Long> getLineIds() {
+        return lineIds;
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+}

--- a/src/main/java/wooteco/subway/domain/ShortestPathEdge.java
+++ b/src/main/java/wooteco/subway/domain/ShortestPathEdge.java
@@ -1,4 +1,4 @@
-package wooteco.subway.service;
+package wooteco.subway.domain;
 
 import org.jgrapht.graph.DefaultWeightedEdge;
 

--- a/src/main/java/wooteco/subway/domain/Station.java
+++ b/src/main/java/wooteco/subway/domain/Station.java
@@ -9,10 +9,17 @@ public class Station {
     public Station(Long id, String name) {
         this.id = id;
         this.name = name;
+        validateStation(name);
     }
 
     public Station(String name) {
         this(null, name);
+    }
+
+    private void validateStation(String name) {
+        if (name.isBlank()) {
+            throw new IllegalArgumentException("이름은 빈 값일 수 없습니다.");
+        }
     }
 
     public boolean isSameStation(Long stationId) {

--- a/src/main/java/wooteco/subway/dto/LineRequest.java
+++ b/src/main/java/wooteco/subway/dto/LineRequest.java
@@ -1,11 +1,25 @@
 package wooteco.subway.dto;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
 public class LineRequest {
+    @NotBlank(message = "노선의 이름을 입력해주세요.")
     private String name;
+
+    @NotBlank(message = "노선의 색깔을 정해주세요.")
     private String color;
+
+    @NotNull(message = "노선의 상행역을 입력해주세요.")
     private Long upStationId;
+
+    @NotNull(message = "노선의 하행역을 입력해주세요.")
     private Long downStationId;
+
+    @Min(value = 1, message = "거리는 자연수여야 합니다.")
     private int distance;
+
     private int extraFare;
 
     private LineRequest() {

--- a/src/main/java/wooteco/subway/dto/LineRequest.java
+++ b/src/main/java/wooteco/subway/dto/LineRequest.java
@@ -1,14 +1,18 @@
 package wooteco.subway.dto;
 
+import org.hibernate.validator.constraints.Length;
+
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 public class LineRequest {
     @NotBlank(message = "노선의 이름을 입력해주세요.")
+    @Length(max = 255)
     private String name;
 
     @NotBlank(message = "노선의 색깔을 정해주세요.")
+    @Length(max = 20)
     private String color;
 
     @NotNull(message = "노선의 상행역을 입력해주세요.")

--- a/src/main/java/wooteco/subway/dto/PathRequest.java
+++ b/src/main/java/wooteco/subway/dto/PathRequest.java
@@ -1,8 +1,16 @@
 package wooteco.subway.dto;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
 public class PathRequest {
+    @NotNull(message = "출발역을 입력해야 합니다.")
     private Long source;
+
+    @NotNull(message = "도착역을 입력해야 합니다.")
     private Long target;
+
+    @Min(value = 0, message = "올바른 나이를 입력해야 합니다.")
     private int age;
 
     private PathRequest() {

--- a/src/main/java/wooteco/subway/dto/PathRequest.java
+++ b/src/main/java/wooteco/subway/dto/PathRequest.java
@@ -1,0 +1,28 @@
+package wooteco.subway.dto;
+
+public class PathRequest {
+    private Long source;
+    private Long target;
+    private int age;
+
+    private PathRequest() {
+    }
+
+    public PathRequest(Long source, Long target, int age) {
+        this.source = source;
+        this.target = target;
+        this.age = age;
+    }
+
+    public Long getSource() {
+        return source;
+    }
+
+    public Long getTarget() {
+        return target;
+    }
+
+    public int getAge() {
+        return age;
+    }
+}

--- a/src/main/java/wooteco/subway/dto/SectionRequest.java
+++ b/src/main/java/wooteco/subway/dto/SectionRequest.java
@@ -1,8 +1,16 @@
 package wooteco.subway.dto;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
 public class SectionRequest {
+    @NotNull(message = "상행역을 입력해야 합니다.")
     private Long upStationId;
+
+    @NotNull(message = "하행역을 입력해야 합니다.")
     private Long downStationId;
+
+    @Min(value = 1, message = "거리는 자연수여야 합니다.")
     private int distance;
 
     private SectionRequest() {

--- a/src/main/java/wooteco/subway/dto/StationRequest.java
+++ b/src/main/java/wooteco/subway/dto/StationRequest.java
@@ -1,9 +1,12 @@
 package wooteco.subway.dto;
 
+import org.hibernate.validator.constraints.Length;
+
 import javax.validation.constraints.NotBlank;
 
 public class StationRequest {
     @NotBlank(message = "역 이름을 입력해야 합니다.")
+    @Length(max = 255)
     private String name;
 
     private StationRequest() {

--- a/src/main/java/wooteco/subway/dto/StationRequest.java
+++ b/src/main/java/wooteco/subway/dto/StationRequest.java
@@ -1,6 +1,9 @@
 package wooteco.subway.dto;
 
+import javax.validation.constraints.NotBlank;
+
 public class StationRequest {
+    @NotBlank(message = "역 이름을 입력해야 합니다.")
     private String name;
 
     private StationRequest() {

--- a/src/main/java/wooteco/subway/service/PathService.java
+++ b/src/main/java/wooteco/subway/service/PathService.java
@@ -8,10 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import wooteco.subway.dao.LineDao;
 import wooteco.subway.dao.SectionDao;
 import wooteco.subway.dao.StationDao;
-import wooteco.subway.domain.Fare;
-import wooteco.subway.domain.Line;
-import wooteco.subway.domain.Section;
-import wooteco.subway.domain.Station;
+import wooteco.subway.domain.*;
 import wooteco.subway.dto.PathResponse;
 
 import java.util.Comparator;

--- a/src/main/java/wooteco/subway/service/PathService.java
+++ b/src/main/java/wooteco/subway/service/PathService.java
@@ -96,6 +96,7 @@ public class PathService {
     private int findMaximumExtraFare(GraphPath<Station, ShortestPathEdge> graphPath) {
         return graphPath.getEdgeList().stream()
                 .map(ShortestPathEdge::getLineId)
+                .distinct()
                 .map(lineId -> lineDao.findById(lineId)
                         .orElseThrow(() -> new NoSuchElementException("경로 라인을 찾는 과정 중 오류가 발생했습니다.")))
                 .max(Comparator.comparingInt(Line::getExtraFare))

--- a/src/main/java/wooteco/subway/service/PathService.java
+++ b/src/main/java/wooteco/subway/service/PathService.java
@@ -2,39 +2,45 @@ package wooteco.subway.service;
 
 import org.jgrapht.GraphPath;
 import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
-import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.WeightedMultigraph;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import wooteco.subway.dao.LineDao;
 import wooteco.subway.dao.SectionDao;
 import wooteco.subway.dao.StationDao;
 import wooteco.subway.domain.Fare;
+import wooteco.subway.domain.Line;
 import wooteco.subway.domain.Section;
 import wooteco.subway.domain.Station;
 import wooteco.subway.dto.PathResponse;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 
 @Transactional(readOnly = true)
 @Service
 public class PathService {
     private final StationDao stationDao;
+    private final LineDao lineDao;
     private final SectionDao sectionDao;
 
-    public PathService(StationDao stationDao, SectionDao sectionDao) {
+    public PathService(StationDao stationDao, LineDao lineDao, SectionDao sectionDao) {
         this.stationDao = stationDao;
+        this.lineDao = lineDao;
         this.sectionDao = sectionDao;
     }
 
-    public PathResponse findShortestPath(Long upStationId, Long downStationId) {
+    public PathResponse findShortestPath(Long upStationId, Long downStationId, int age) {
         validateNotSameStations(upStationId, downStationId);
-        final GraphPath<Station, DefaultWeightedEdge> graphPath = findGraphPath(upStationId, downStationId);
+        final GraphPath<Station, ShortestPathEdge> graphPath = findGraphPath(upStationId, downStationId);
         validatePathExist(graphPath);
 
         final List<Station> stations = graphPath.getVertexList();
         final int shortestDistance = (int) graphPath.getWeight();
-        final Fare fare = Fare.from(shortestDistance);
+        final int extraFare = findMaximumExtraFare(graphPath);
+        final Fare fare = Fare.of(shortestDistance, extraFare, age);
         return new PathResponse(stations, shortestDistance, fare.getValue());
     }
 
@@ -44,8 +50,8 @@ public class PathService {
         }
     }
 
-    private GraphPath<Station, DefaultWeightedEdge> findGraphPath(Long upStationId, Long downStationId) {
-        final DijkstraShortestPath<Station, DefaultWeightedEdge> dijkstraShortestPath =
+    private GraphPath<Station, ShortestPathEdge> findGraphPath(Long upStationId, Long downStationId) {
+        final DijkstraShortestPath<Station, ShortestPathEdge> dijkstraShortestPath =
                 new DijkstraShortestPath<>(initSubwayMap());
 
         final Station upStation = findStation(upStationId);
@@ -53,38 +59,50 @@ public class PathService {
         return dijkstraShortestPath.getPath(upStation, downStation);
     }
 
-    private void validatePathExist(GraphPath<Station, DefaultWeightedEdge> graphPath) {
+    private void validatePathExist(GraphPath<Station, ShortestPathEdge> graphPath) {
         if (graphPath == null) {
             throw new IllegalArgumentException("해당 역 사이 경로가 존재하지 않습니다.");
         }
     }
 
-    private WeightedMultigraph<Station, DefaultWeightedEdge> initSubwayMap() {
-        final WeightedMultigraph<Station, DefaultWeightedEdge> graph
-                = new WeightedMultigraph<>(DefaultWeightedEdge.class);
+    private WeightedMultigraph<Station, ShortestPathEdge> initSubwayMap() {
+        final WeightedMultigraph<Station, ShortestPathEdge> graph
+                = new WeightedMultigraph<>(ShortestPathEdge.class);
         addAllStations(graph);
         addAllSections(graph);
         return graph;
     }
 
-    private void addAllStations(WeightedMultigraph<Station, DefaultWeightedEdge> graph) {
+    private void addAllStations(WeightedMultigraph<Station, ShortestPathEdge> graph) {
         final List<Station> stations = stationDao.findAll();
         for (Station station : stations) {
             graph.addVertex(station);
         }
     }
 
-    private void addAllSections(WeightedMultigraph<Station, DefaultWeightedEdge> graph) {
+    private void addAllSections(WeightedMultigraph<Station, ShortestPathEdge> graph) {
         final List<Section> sections = sectionDao.findAll();
         for (Section section : sections) {
             final Station upStation = findStation(section.getUpStationId());
             final Station downStation = findStation(section.getDownStationId());
-            graph.setEdgeWeight(graph.addEdge(upStation, downStation), section.getDistance());
+            final Long lineId = section.getLineId();
+            final int distance = section.getDistance();
+            graph.addEdge(upStation, downStation, new ShortestPathEdge(lineId, distance));
         }
     }
 
     private Station findStation(Long id) {
         return stationDao.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 역이 존재하지 않습니다."));
+    }
+
+    private int findMaximumExtraFare(GraphPath<Station, ShortestPathEdge> graphPath) {
+        return graphPath.getEdgeList().stream()
+                .map(ShortestPathEdge::getLineId)
+                .map(lineId -> lineDao.findById(lineId)
+                        .orElseThrow(() -> new NoSuchElementException("경로 라인을 찾는 과정 중 오류가 발생했습니다.")))
+                .max(Comparator.comparingInt(Line::getExtraFare))
+                .orElseThrow(() -> new NoSuchElementException("추가 요금을 찾는 과정 중 오류가 발생했습니다."))
+                .getExtraFare();
     }
 }

--- a/src/main/java/wooteco/subway/service/PathService.java
+++ b/src/main/java/wooteco/subway/service/PathService.java
@@ -1,8 +1,5 @@
 package wooteco.subway.service;
 
-import org.jgrapht.GraphPath;
-import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
-import org.jgrapht.graph.WeightedMultigraph;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wooteco.subway.dao.LineDao;
@@ -10,6 +7,8 @@ import wooteco.subway.dao.SectionDao;
 import wooteco.subway.dao.StationDao;
 import wooteco.subway.domain.*;
 import wooteco.subway.dto.PathResponse;
+import wooteco.subway.service.pathInfra.PathFinder;
+import wooteco.subway.service.pathInfra.ShortestPathFinder;
 
 import java.util.Comparator;
 import java.util.List;
@@ -31,14 +30,19 @@ public class PathService {
 
     public PathResponse findShortestPath(Long upStationId, Long downStationId, int age) {
         validateNotSameStations(upStationId, downStationId);
-        final GraphPath<Station, ShortestPathEdge> graphPath = findGraphPath(upStationId, downStationId);
-        validatePathExist(graphPath);
+        final Path shortestPath = makePath(upStationId, downStationId);
 
-        final List<Station> stations = graphPath.getVertexList();
-        final int shortestDistance = (int) graphPath.getWeight();
-        final int extraFare = findMaximumExtraFare(graphPath);
+        final List<Station> stations = shortestPath.getStations();
+        final int shortestDistance = shortestPath.getDistance();
+        final int extraFare = findMaximumExtraFare(shortestPath);
         final Fare fare = Fare.of(shortestDistance, extraFare, age);
         return new PathResponse(stations, shortestDistance, fare.getValue());
+    }
+
+    private Path makePath(Long upStationId, Long downStationId) {
+        final PathFinder pathFinder = new ShortestPathFinder(stationDao);
+        final List<Section> sections = sectionDao.findAll();
+        return pathFinder.findShortestPath(sections, upStationId, downStationId);
     }
 
     private void validateNotSameStations(Long upStationId, Long downStationId) {
@@ -47,56 +51,9 @@ public class PathService {
         }
     }
 
-    private GraphPath<Station, ShortestPathEdge> findGraphPath(Long upStationId, Long downStationId) {
-        final DijkstraShortestPath<Station, ShortestPathEdge> dijkstraShortestPath =
-                new DijkstraShortestPath<>(initSubwayMap());
-
-        final Station upStation = findStation(upStationId);
-        final Station downStation = findStation(downStationId);
-        return dijkstraShortestPath.getPath(upStation, downStation);
-    }
-
-    private void validatePathExist(GraphPath<Station, ShortestPathEdge> graphPath) {
-        if (graphPath == null) {
-            throw new IllegalArgumentException("해당 역 사이 경로가 존재하지 않습니다.");
-        }
-    }
-
-    private WeightedMultigraph<Station, ShortestPathEdge> initSubwayMap() {
-        final WeightedMultigraph<Station, ShortestPathEdge> graph
-                = new WeightedMultigraph<>(ShortestPathEdge.class);
-        addAllStations(graph);
-        addAllSections(graph);
-        return graph;
-    }
-
-    private void addAllStations(WeightedMultigraph<Station, ShortestPathEdge> graph) {
-        final List<Station> stations = stationDao.findAll();
-        for (Station station : stations) {
-            graph.addVertex(station);
-        }
-    }
-
-    private void addAllSections(WeightedMultigraph<Station, ShortestPathEdge> graph) {
-        final List<Section> sections = sectionDao.findAll();
-        for (Section section : sections) {
-            final Station upStation = findStation(section.getUpStationId());
-            final Station downStation = findStation(section.getDownStationId());
-            final Long lineId = section.getLineId();
-            final int distance = section.getDistance();
-            graph.addEdge(upStation, downStation, new ShortestPathEdge(lineId, distance));
-        }
-    }
-
-    private Station findStation(Long id) {
-        return stationDao.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 역이 존재하지 않습니다."));
-    }
-
-    private int findMaximumExtraFare(GraphPath<Station, ShortestPathEdge> graphPath) {
-        return graphPath.getEdgeList().stream()
-                .map(ShortestPathEdge::getLineId)
-                .distinct()
+    private int findMaximumExtraFare(Path shortestPath) {
+        return shortestPath.getLineIds()
+                .stream()
                 .map(lineId -> lineDao.findById(lineId)
                         .orElseThrow(() -> new NoSuchElementException("경로 라인을 찾는 과정 중 오류가 발생했습니다.")))
                 .max(Comparator.comparingInt(Line::getExtraFare))

--- a/src/main/java/wooteco/subway/service/PathService.java
+++ b/src/main/java/wooteco/subway/service/PathService.java
@@ -6,6 +6,7 @@ import wooteco.subway.dao.LineDao;
 import wooteco.subway.dao.SectionDao;
 import wooteco.subway.dao.StationDao;
 import wooteco.subway.domain.*;
+import wooteco.subway.dto.PathRequest;
 import wooteco.subway.dto.PathResponse;
 import wooteco.subway.service.pathInfra.PathFinder;
 import wooteco.subway.service.pathInfra.ShortestPathFinder;
@@ -28,25 +29,25 @@ public class PathService {
         this.sectionDao = sectionDao;
     }
 
-    public PathResponse findShortestPath(Long upStationId, Long downStationId, int age) {
-        validateNotSameStations(upStationId, downStationId);
-        final Path shortestPath = makePath(upStationId, downStationId);
+    public PathResponse findShortestPath(PathRequest pathRequest) {
+        validateNotSameStations(pathRequest.getSource(), pathRequest.getTarget());
+        final Path shortestPath = makePath(pathRequest.getSource(), pathRequest.getTarget());
 
         final List<Station> stations = shortestPath.getStations();
         final int shortestDistance = shortestPath.getDistance();
         final int extraFare = findMaximumExtraFare(shortestPath);
-        final Fare fare = Fare.of(shortestDistance, extraFare, age);
+        final Fare fare = Fare.of(shortestDistance, extraFare, pathRequest.getAge());
         return new PathResponse(stations, shortestDistance, fare.getValue());
     }
 
-    private Path makePath(Long upStationId, Long downStationId) {
+    private Path makePath(Long source, Long target) {
         final PathFinder pathFinder = new ShortestPathFinder(stationDao);
         final List<Section> sections = sectionDao.findAll();
-        return pathFinder.findShortestPath(sections, upStationId, downStationId);
+        return pathFinder.findShortestPath(sections, source, target);
     }
 
-    private void validateNotSameStations(Long upStationId, Long downStationId) {
-        if (Objects.equals(upStationId, downStationId)) {
+    private void validateNotSameStations(Long source, Long target) {
+        if (Objects.equals(source, target)) {
             throw new IllegalArgumentException("출발역과 도착역이 같을 수 없습니다.");
         }
     }

--- a/src/main/java/wooteco/subway/service/PathService.java
+++ b/src/main/java/wooteco/subway/service/PathService.java
@@ -52,7 +52,7 @@ public class PathService {
     }
 
     private int findMaximumExtraFare(Path shortestPath) {
-        return shortestPath.getLineIds()
+        return shortestPath.getIncludeLineIds()
                 .stream()
                 .map(lineId -> lineDao.findById(lineId)
                         .orElseThrow(() -> new NoSuchElementException("경로 라인을 찾는 과정 중 오류가 발생했습니다.")))

--- a/src/main/java/wooteco/subway/service/PathService.java
+++ b/src/main/java/wooteco/subway/service/PathService.java
@@ -52,10 +52,8 @@ public class PathService {
     }
 
     private int findMaximumExtraFare(Path shortestPath) {
-        return shortestPath.getIncludeLineIds()
+        return lineDao.findByIds(shortestPath.getIncludeLineIds())
                 .stream()
-                .map(lineId -> lineDao.findById(lineId)
-                        .orElseThrow(() -> new NoSuchElementException("경로 라인을 찾는 과정 중 오류가 발생했습니다.")))
                 .max(Comparator.comparingInt(Line::getExtraFare))
                 .orElseThrow(() -> new NoSuchElementException("추가 요금을 찾는 과정 중 오류가 발생했습니다."))
                 .getExtraFare();

--- a/src/main/java/wooteco/subway/service/ShortestPathEdge.java
+++ b/src/main/java/wooteco/subway/service/ShortestPathEdge.java
@@ -1,0 +1,22 @@
+package wooteco.subway.service;
+
+import org.jgrapht.graph.DefaultWeightedEdge;
+
+public class ShortestPathEdge extends DefaultWeightedEdge {
+    private final Long lineId;
+    private final int distance;
+
+    public ShortestPathEdge(Long lineId, int distance) {
+        this.lineId = lineId;
+        this.distance = distance;
+    }
+
+    public Long getLineId() {
+        return lineId;
+    }
+
+    @Override
+    protected double getWeight() {
+        return distance;
+    }
+}

--- a/src/main/java/wooteco/subway/service/pathInfra/PathFinder.java
+++ b/src/main/java/wooteco/subway/service/pathInfra/PathFinder.java
@@ -1,0 +1,10 @@
+package wooteco.subway.service.pathInfra;
+
+import wooteco.subway.domain.Path;
+import wooteco.subway.domain.Section;
+
+import java.util.List;
+
+public interface PathFinder {
+    Path findShortestPath(List<Section> sections, Long sourceId, Long targetId);
+}

--- a/src/main/java/wooteco/subway/service/pathInfra/ShortestPathEdge.java
+++ b/src/main/java/wooteco/subway/service/pathInfra/ShortestPathEdge.java
@@ -1,4 +1,4 @@
-package wooteco.subway.domain;
+package wooteco.subway.service.pathInfra;
 
 import org.jgrapht.graph.DefaultWeightedEdge;
 

--- a/src/main/java/wooteco/subway/service/pathInfra/ShortestPathFinder.java
+++ b/src/main/java/wooteco/subway/service/pathInfra/ShortestPathFinder.java
@@ -29,26 +29,8 @@ public class ShortestPathFinder implements PathFinder {
         final Station target = findStation(targetId);
         final GraphPath<Station, ShortestPathEdge> graphPath = new DijkstraShortestPath<>(graph).getPath(source, target);
         validatePathExist(graphPath);
-        return getPath(graphPath);
+        return makePath(graphPath);
     }
-
-    private void validatePathExist(GraphPath<Station, ShortestPathEdge> graphPath) {
-        if (graphPath == null) {
-            throw new IllegalArgumentException("해당 역 사이 경로가 존재하지 않습니다.");
-        }
-    }
-
-    private Path getPath(GraphPath<Station, ShortestPathEdge> graphPath) {
-        final List<Station> stations = graphPath.getVertexList();
-        final List<Long> lineIds = graphPath.getEdgeList()
-                .stream()
-                .map(ShortestPathEdge::getLineId)
-                .distinct()
-                .collect(Collectors.toUnmodifiableList());
-        final int distance = (int) graphPath.getWeight();
-        return new Path(stations, lineIds, distance);
-    }
-
 
     private void addAllStations(WeightedMultigraph<Station, ShortestPathEdge> graph) {
         List<Station> stations = stationDao.findAll();
@@ -70,5 +52,22 @@ public class ShortestPathFinder implements PathFinder {
     private Station findStation(Long id) {
         return stationDao.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 역이 존재하지 않습니다."));
+    }
+
+    private void validatePathExist(GraphPath<Station, ShortestPathEdge> graphPath) {
+        if (graphPath == null) {
+            throw new IllegalArgumentException("해당 역 사이 경로가 존재하지 않습니다.");
+        }
+    }
+
+    private Path makePath(GraphPath<Station, ShortestPathEdge> graphPath) {
+        final List<Station> stations = graphPath.getVertexList();
+        final List<Long> lineIds = graphPath.getEdgeList()
+                .stream()
+                .map(ShortestPathEdge::getLineId)
+                .distinct()
+                .collect(Collectors.toUnmodifiableList());
+        final int distance = (int) graphPath.getWeight();
+        return new Path(stations, lineIds, distance);
     }
 }

--- a/src/main/java/wooteco/subway/service/pathInfra/ShortestPathFinder.java
+++ b/src/main/java/wooteco/subway/service/pathInfra/ShortestPathFinder.java
@@ -1,0 +1,74 @@
+package wooteco.subway.service.pathInfra;
+
+import org.jgrapht.GraphPath;
+import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
+import org.jgrapht.graph.WeightedMultigraph;
+import wooteco.subway.dao.StationDao;
+import wooteco.subway.domain.Path;
+import wooteco.subway.domain.Section;
+import wooteco.subway.domain.Station;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ShortestPathFinder implements PathFinder {
+    private final StationDao stationDao;
+
+    public ShortestPathFinder(StationDao stationDao) {
+        this.stationDao = stationDao;
+    }
+
+    @Override
+    public Path findShortestPath(List<Section> sections, Long sourceId, Long targetId) {
+        final WeightedMultigraph<Station, ShortestPathEdge> graph
+                = new WeightedMultigraph<>(ShortestPathEdge.class);
+        addAllStations(graph);
+        addAllSections(graph, sections);
+
+        final Station source = findStation(sourceId);
+        final Station target = findStation(targetId);
+        final GraphPath<Station, ShortestPathEdge> graphPath = new DijkstraShortestPath<>(graph).getPath(source, target);
+        validatePathExist(graphPath);
+        return getPath(graphPath);
+    }
+
+    private void validatePathExist(GraphPath<Station, ShortestPathEdge> graphPath) {
+        if (graphPath == null) {
+            throw new IllegalArgumentException("해당 역 사이 경로가 존재하지 않습니다.");
+        }
+    }
+
+    private Path getPath(GraphPath<Station, ShortestPathEdge> graphPath) {
+        final List<Station> stations = graphPath.getVertexList();
+        final List<Long> lineIds = graphPath.getEdgeList()
+                .stream()
+                .map(ShortestPathEdge::getLineId)
+                .distinct()
+                .collect(Collectors.toUnmodifiableList());
+        final int distance = (int) graphPath.getWeight();
+        return new Path(stations, lineIds, distance);
+    }
+
+
+    private void addAllStations(WeightedMultigraph<Station, ShortestPathEdge> graph) {
+        List<Station> stations = stationDao.findAll();
+        for (Station station : stations) {
+            graph.addVertex(station);
+        }
+    }
+
+    private void addAllSections(WeightedMultigraph<Station, ShortestPathEdge> graph, List<Section> sections) {
+        for (Section section : sections) {
+            final Station upStation = findStation(section.getUpStationId());
+            final Station downStation = findStation(section.getDownStationId());
+            final Long lineId = section.getLineId();
+            final int distance = section.getDistance();
+            graph.addEdge(upStation, downStation, new ShortestPathEdge(lineId, distance));
+        }
+    }
+
+    private Station findStation(Long id) {
+        return stationDao.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 역이 존재하지 않습니다."));
+    }
+}

--- a/src/main/java/wooteco/subway/ui/LineController.java
+++ b/src/main/java/wooteco/subway/ui/LineController.java
@@ -7,6 +7,7 @@ import wooteco.subway.dto.LineResponse;
 import wooteco.subway.dto.SectionRequest;
 import wooteco.subway.service.LineService;
 
+import javax.validation.Valid;
 import java.net.URI;
 import java.util.List;
 
@@ -20,7 +21,7 @@ public class LineController {
     }
 
     @PostMapping
-    public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
+    public ResponseEntity<LineResponse> createLine(@Valid @RequestBody LineRequest lineRequest) {
         final LineResponse lineResponse = lineService.saveLine(lineRequest);
         return ResponseEntity.created(URI.create("/lines/" + lineResponse.getId())).body(lineResponse);
     }
@@ -38,7 +39,7 @@ public class LineController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<Void> updateLine(@PathVariable Long id, @RequestBody LineRequest lineRequest) {
+    public ResponseEntity<Void> updateLine(@PathVariable Long id, @Valid @RequestBody LineRequest lineRequest) {
         lineService.updateLine(id, lineRequest.getName(), lineRequest.getColor(), lineRequest.getExtraFare());
         return ResponseEntity.ok().build();
     }
@@ -50,7 +51,7 @@ public class LineController {
     }
 
     @PostMapping("/{id}/sections")
-    public ResponseEntity<Void> createSection(@PathVariable Long id, @RequestBody SectionRequest sectionRequest) {
+    public ResponseEntity<Void> createSection(@PathVariable Long id, @Valid @RequestBody SectionRequest sectionRequest) {
         lineService.addSection(id, sectionRequest);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/wooteco/subway/ui/PathController.java
+++ b/src/main/java/wooteco/subway/ui/PathController.java
@@ -20,7 +20,7 @@ public class PathController {
     @GetMapping
     public ResponseEntity<PathResponse> showPath(@RequestParam Long source, @RequestParam Long target,
                                                  @RequestParam int age) {
-        PathResponse pathResponse = pathService.findShortestPath(source, target);
+        PathResponse pathResponse = pathService.findShortestPath(source, target, age);
         return ResponseEntity.ok().body(pathResponse);
     }
 }

--- a/src/main/java/wooteco/subway/ui/PathController.java
+++ b/src/main/java/wooteco/subway/ui/PathController.java
@@ -20,7 +20,7 @@ public class PathController {
     @GetMapping
     public ResponseEntity<PathResponse> showPath(@RequestParam Long source, @RequestParam Long target,
                                                  @RequestParam int age) {
-        PathResponse pathResponse = pathService.findShortestPath(source, target, age);
+        final PathResponse pathResponse = pathService.findShortestPath(source, target, age);
         return ResponseEntity.ok().body(pathResponse);
     }
 }

--- a/src/main/java/wooteco/subway/ui/PathController.java
+++ b/src/main/java/wooteco/subway/ui/PathController.java
@@ -3,8 +3,8 @@ package wooteco.subway.ui;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import wooteco.subway.dto.PathRequest;
 import wooteco.subway.dto.PathResponse;
 import wooteco.subway.service.PathService;
 
@@ -18,9 +18,8 @@ public class PathController {
     }
 
     @GetMapping
-    public ResponseEntity<PathResponse> showPath(@RequestParam Long source, @RequestParam Long target,
-                                                 @RequestParam int age) {
-        final PathResponse pathResponse = pathService.findShortestPath(source, target, age);
+    public ResponseEntity<PathResponse> showPath(PathRequest pathRequest) {
+        final PathResponse pathResponse = pathService.findShortestPath(pathRequest);
         return ResponseEntity.ok().body(pathResponse);
     }
 }

--- a/src/main/java/wooteco/subway/ui/PathController.java
+++ b/src/main/java/wooteco/subway/ui/PathController.java
@@ -8,6 +8,8 @@ import wooteco.subway.dto.PathRequest;
 import wooteco.subway.dto.PathResponse;
 import wooteco.subway.service.PathService;
 
+import javax.validation.Valid;
+
 @RestController
 @RequestMapping("/paths")
 public class PathController {
@@ -18,7 +20,7 @@ public class PathController {
     }
 
     @GetMapping
-    public ResponseEntity<PathResponse> showPath(PathRequest pathRequest) {
+    public ResponseEntity<PathResponse> showPath(@Valid PathRequest pathRequest) {
         final PathResponse pathResponse = pathService.findShortestPath(pathRequest);
         return ResponseEntity.ok().body(pathResponse);
     }

--- a/src/main/java/wooteco/subway/ui/StationController.java
+++ b/src/main/java/wooteco/subway/ui/StationController.java
@@ -7,6 +7,7 @@ import wooteco.subway.dto.StationRequest;
 import wooteco.subway.dto.StationResponse;
 import wooteco.subway.service.StationService;
 
+import javax.validation.Valid;
 import java.net.URI;
 import java.util.List;
 
@@ -20,7 +21,7 @@ public class StationController {
     }
 
     @PostMapping
-    public ResponseEntity<StationResponse> createStation(@RequestBody StationRequest stationRequest) {
+    public ResponseEntity<StationResponse> createStation(@Valid @RequestBody StationRequest stationRequest) {
         final StationResponse stationResponse = stationService.saveStation(stationRequest);
         return ResponseEntity.created(URI.create("/stations/" + stationResponse.getId())).body(stationResponse);
     }

--- a/src/main/java/wooteco/subway/ui/SubwayControllerAdvice.java
+++ b/src/main/java/wooteco/subway/ui/SubwayControllerAdvice.java
@@ -1,19 +1,31 @@
 package wooteco.subway.ui;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import wooteco.subway.dto.ErrorResponse;
 
+import java.util.stream.Collectors;
+
 @ControllerAdvice
 public class SubwayControllerAdvice {
-    @ExceptionHandler
-    public ResponseEntity<ErrorResponse> handleError(Exception e) {
-        return ResponseEntity.internalServerError().body(new ErrorResponse(e.getMessage()));
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> requestBodyInvalidError(MethodArgumentNotValidException e) {
+        final String message = e.getFieldErrors().stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.joining(" "));
+        return ResponseEntity.badRequest().body(new ErrorResponse(message));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleClientError(Exception e) {
         return ResponseEntity.badRequest().body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> handleError(Exception e) {
+        return ResponseEntity.internalServerError().body(new ErrorResponse(e.getMessage()));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 server:
   port: 8081
 spring:
-  datasource:           # datasource 설정
+  datasource: # datasource 설정
     driver-class-name: org.h2.Driver
     url: jdbc:h2:mem:testdb
     username: sa

--- a/src/main/resources/logback-access.xml
+++ b/src/main/resources/logback-access.xml
@@ -1,8 +1,9 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%n###### HTTP Request ######%n%fullRequest%n###### HTTP Response ######%n%fullResponse%n%n</pattern>
+            <pattern>%n###### HTTP Request ######%n%fullRequest%n###### HTTP Response ######%n%fullResponse%n%n
+            </pattern>
         </encoder>
     </appender>
-    <appender-ref ref="STDOUT" />
+    <appender-ref ref="STDOUT"/>
 </configuration>

--- a/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/wooteco/subway/acceptance/LineAcceptanceTest.java
@@ -7,15 +7,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import wooteco.subway.dto.LineRequest;
 import wooteco.subway.dto.LineResponse;
 import wooteco.subway.dto.StationRequest;
 
+import javax.validation.Validator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -30,6 +33,20 @@ public class LineAcceptanceTest extends AcceptanceTest {
     private final LineRequest lineRequest2 =
             new LineRequest("분당선", "bg-green-600",
                     1L, 3L, 15, 900);
+
+    @DisplayName("지하철 노선 생성 요청값의 거리가 0일 때 예외를 발생시킨다.")
+    @Test
+    void createLineRequestWithNotDistance() {
+        final LineRequest lineRequest = new LineRequest("신분당선", "bg-red-600",
+                1L, 2L, 0, 900);
+        RestAssured.given().log().all()
+                .body(lineRequest)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .statusCode(equalTo(HttpStatus.BAD_REQUEST.value()));
+    }
 
     @DisplayName("지하철노선을 생성한다.")
     @Test

--- a/src/test/java/wooteco/subway/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/wooteco/subway/acceptance/PathAcceptanceTest.java
@@ -6,6 +6,8 @@ import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import wooteco.subway.dto.LineRequest;
@@ -30,10 +32,10 @@ public class PathAcceptanceTest extends AcceptanceTest {
 
     private final LineRequest 이호선 =
             new LineRequest("2호선", "bg-green-600",
-                    1L, 3L, 103, 900);
+                    1L, 3L, 103, 500);
     private final LineRequest 팔호선 =
             new LineRequest("8호선", "bg-red-600",
-                    1L, 4L, 10, 900);
+                    1L, 4L, 10, 700);
     private final LineRequest 구호선 =
             new LineRequest("9호선", "bg-gray-600",
                     4L, 3L, 3, 900);
@@ -60,36 +62,39 @@ public class PathAcceptanceTest extends AcceptanceTest {
         createSectionResponse(3L, 석촌고분_삼전);
     }
 
-    @Test
-    @DisplayName("10km 이하의 최단경로를 찾는다.")
-    void findShortestPath10KM() {
-        ExtractableResponse<Response> response = createPathResponse(4L, 6L, 10);
+    @ParameterizedTest
+    @DisplayName("10km 이하의 최단경로 정보를 나이에 따른 할증을 고려하여 찾는다.")
+    @CsvSource(value = {"5, 2150", "6, 1250", "12, 1250", "13, 1790", "18, 1790", "19, 2150"})
+    void findShortestPath10KM(int age, int expectedFare) {
+        ExtractableResponse<Response> response = createPathResponse(4L, 6L, age);
 
-        checkByValidPath(response, 2, 1250, 석촌.getName(), 석촌고분.getName(), 삼전.getName());
+        checkByValidPath(response, 2, expectedFare, 석촌.getName(), 석촌고분.getName(), 삼전.getName());
     }
 
-    @Test
-    @DisplayName("50km 이하의 최단경로를 찾는다.")
+    @ParameterizedTest
+    @DisplayName("50km 이하의 최단경로 정보를 나이에 따른 할증을 고려하여 찾는다.")
+    @CsvSource(value = {"5, 2550", "6, 1450", "12, 1450", "13, 2110", "18, 2110", "19, 2550"})
     void findShortestPath50KM() {
-        ExtractableResponse<Response> response = createPathResponse(1L, 2L, 10);
+        ExtractableResponse<Response> response = createPathResponse(1L, 2L, 19);
 
-        checkByValidPath(response, 50, 2050, 잠실.getName(), 잠실새내.getName());
+        checkByValidPath(response, 50, 2550, 잠실.getName(), 잠실새내.getName());
     }
 
-    @Test
-    @DisplayName("50km 초과의 최단경로를 찾는다.")
+    @ParameterizedTest
+    @DisplayName("50km 초과의 최단경로 정보를 나이에 따른 할증을 고려하여 찾는다.")
+    @CsvSource(value = {"5, 2650", "6, 1500", "12, 1500", "13, 2190", "18, 2190", "19, 2650"})
     void findShortestPathGreaterThan50KM() {
-        ExtractableResponse<Response> response = createPathResponse(2L, 3L, 10);
+        ExtractableResponse<Response> response = createPathResponse(2L, 3L, 19);
 
-        checkByValidPath(response, 53, 2150, 잠실새내.getName(), 종합운동장.getName());
+        checkByValidPath(response, 53, 2650, 잠실새내.getName(), 종합운동장.getName());
     }
 
     @Test
-    @DisplayName("여러 노선의 환승을 고려하여 최단경로를 찾는다.")
+    @DisplayName("여러 노선의 환승을 고려하여 최단경로 정보를 찾는다.")
     void findShortestPathWhenMultiLines() {
-        ExtractableResponse<Response> response = createPathResponse(1L, 3L, 10);
+        ExtractableResponse<Response> response = createPathResponse(1L, 3L, 19);
 
-        checkByValidPath(response, 13, 1350,
+        checkByValidPath(response, 13, 2250,
                 잠실.getName(), 석촌.getName(), 석촌고분.getName(), 삼전.getName(), 종합운동장.getName());
     }
 

--- a/src/test/java/wooteco/subway/dao/JdbcLineDaoTest.java
+++ b/src/test/java/wooteco/subway/dao/JdbcLineDaoTest.java
@@ -9,7 +9,10 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import wooteco.subway.domain.Line;
 import wooteco.subway.dto.LineRequest;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @JdbcTest
 public class JdbcLineDaoTest {
@@ -60,6 +63,26 @@ public class JdbcLineDaoTest {
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 노선이 존재하지 않습니다."));
 
         assertThat(actual.getName()).isEqualTo(expected.getName());
+    }
+
+    @Test
+    @DisplayName("지하철 특정 노선들을 조회한다.")
+    void findLines() {
+        final Line line1 = new Line("다른분당선", "bg-blue-600");
+        final long line1Id = lineDao.save(
+                new LineRequest("다른분당선", "bg-blue-600", 2L, 3L, 40)
+        );
+        final Line line2 = new Line("또다른분당선", "bg-gray-600");
+        final long line2Id = lineDao.save(
+                new LineRequest("또다른분당선", "bg-gray-600", 1L, 3L, 20)
+        );
+
+        final List<Line> actual = lineDao.findByIds(List.of(line1Id, line2Id));
+
+        assertAll(
+                () -> assertThat(line1.getName()).isEqualTo("다른분당선"),
+                () -> assertThat(line2.getName()).isEqualTo("또다른분당선")
+        );
     }
 
     @Test

--- a/src/test/java/wooteco/subway/domain/FareTest.java
+++ b/src/test/java/wooteco/subway/domain/FareTest.java
@@ -2,6 +2,8 @@ package wooteco.subway.domain;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,5 +31,40 @@ class FareTest {
         Fare fare = Fare.from(67);
 
         assertThat(fare.getValue()).isEqualTo(2350);
+    }
+
+    @Test
+    @DisplayName("추가 요금이 있는 노선을 이용할 경우 측정된 요금에 추가된다.")
+    void calculateFareWithExtraFare() {
+        Fare fare = Fare.of(50, 900, 20);
+
+        assertThat(fare.getValue()).isEqualTo(2950);
+    }
+
+    @ParameterizedTest
+    @DisplayName("6세 이상 13세 미만은 운임에서 350원을 공제한 금액의 50%를 할인한다.")
+    @CsvSource(value = {"10, 0, 6, 800", "10, 0, 12, 800", "10, 400, 12, 1000"})
+    void calculateFareWithChildren(int distance, int extraFare, int age, int expected) {
+        Fare fare = Fare.of(distance, extraFare, age);
+
+        assertThat(fare.getValue()).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @DisplayName("13세 이상 19세 미만은 운임에서 350원을 공제한 금액의 20%를 할인한다.")
+    @CsvSource(value = {"10, 0, 13, 1070", "10, 0, 18, 1070", "10, 400, 18, 1390"})
+    void calculateFareWithTeenager(int distance, int extraFare, int age, int expected) {
+        Fare fare = Fare.of(distance, extraFare, age);
+
+        assertThat(fare.getValue()).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @DisplayName("6세 미만 또는 19세 이상은 나이 할인이 적용되지 않는다.")
+    @CsvSource(value = {"10, 0, 5, 1250", "10, 0, 19, 1250", "10, 400, 19, 1650"})
+    void calculateFareWithNormalAge(int distance, int extraFare, int age, int expected) {
+        Fare fare = Fare.of(distance, extraFare, age);
+
+        assertThat(fare.getValue()).isEqualTo(expected);
     }
 }

--- a/src/test/java/wooteco/subway/domain/LineTest.java
+++ b/src/test/java/wooteco/subway/domain/LineTest.java
@@ -1,0 +1,24 @@
+package wooteco.subway.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class LineTest {
+    @Test
+    @DisplayName("노선 이름이 빈 값일 때 예외를 발생시킨다.")
+    void invalidLineName() {
+        assertThatThrownBy(() -> new Line("", "green"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이름은 빈 값일 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("노선 색상이 빈 값일 때 예외를 발생시킨다.")
+    void invalidLineColor() {
+        assertThatThrownBy(() -> new Line("2호선", ""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("색상은 빈 값일 수 없습니다.");
+    }
+}

--- a/src/test/java/wooteco/subway/domain/SectionTest.java
+++ b/src/test/java/wooteco/subway/domain/SectionTest.java
@@ -22,7 +22,7 @@ public class SectionTest {
     @Test
     @DisplayName("거리가 0 미만일 경우 예외를 발생시킨다.")
     void validateDistance() {
-        assertThatThrownBy(()->new Section(1L, 3L, 0))
+        assertThatThrownBy(() -> new Section(1L, 3L, 0))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("구간 거리는 0 이하일 수 없습니다.");
     }

--- a/src/test/java/wooteco/subway/domain/StationTest.java
+++ b/src/test/java/wooteco/subway/domain/StationTest.java
@@ -1,0 +1,16 @@
+package wooteco.subway.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class StationTest {
+    @Test
+    @DisplayName("역 이름이 빈 값일 때 예외를 발생시킨다.")
+    void invalidStationName() {
+        assertThatThrownBy(() -> new Station(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이름은 빈 값일 수 없습니다.");
+    }
+}

--- a/src/test/java/wooteco/subway/service/PathServiceTest.java
+++ b/src/test/java/wooteco/subway/service/PathServiceTest.java
@@ -3,9 +3,12 @@ package wooteco.subway.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import wooteco.subway.domain.Line;
 import wooteco.subway.domain.Section;
 import wooteco.subway.domain.Station;
+import wooteco.subway.dto.LineRequest;
 import wooteco.subway.dto.PathResponse;
+import wooteco.subway.service.fakeDao.LineDaoImpl;
 import wooteco.subway.service.fakeDao.SectionDaoImpl;
 import wooteco.subway.service.fakeDao.StationDaoImpl;
 
@@ -16,11 +19,17 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class PathServiceTest {
     private final PathService pathService
-            = new PathService(StationDaoImpl.getInstance(), SectionDaoImpl.getInstance());
+            = new PathService(StationDaoImpl.getInstance(), LineDaoImpl.getInstance(), SectionDaoImpl.getInstance());
 
-    private Station station1;
-    private Station station2;
-    private Station station3;
+    private Station 애플역;
+    private Station 갤럭시역;
+    private Station 옵티머스역;
+    private Long 애플역_id;
+    private Long 갤럭시역_id;
+    private Long 옵티머스역_id;
+
+    private LineRequest 국내선;
+    private LineRequest 해외경유선;
 
     private Section 애플_갤럭시;
     private Section 갤럭시_옵티머스;
@@ -29,29 +38,23 @@ public class PathServiceTest {
     void setUp() {
         final List<Station> stations = StationDaoImpl.getInstance().findAll();
         stations.clear();
+        final List<Line> lines = LineDaoImpl.getInstance().findAll();
+        lines.clear();
         final List<Section> sections = SectionDaoImpl.getInstance().findAll();
         sections.clear();
 
-        station1 = new Station("애플역");
-        station2 = new Station("갤럭시역");
-        station3 = new Station("옵티머스역");
+        initStations();
     }
 
     @Test
     @DisplayName("역 사이 최단 경로를 구한다.")
     void calculateDistance() {
         // given
-        final Long station1_id = StationDaoImpl.getInstance().save(station1);
-        final Long station2_id = StationDaoImpl.getInstance().save(station2);
-        final Long station3_id = StationDaoImpl.getInstance().save(station3);
-        애플_갤럭시 = new Section(station1_id, station2_id, 10);
-        갤럭시_옵티머스 = new Section(station2_id, station3_id, 20);
-        SectionDaoImpl.getInstance().save(애플_갤럭시);
-        SectionDaoImpl.getInstance().save(갤럭시_옵티머스);
+        initLineAndSectionWithNotExtraFare();
         final PathResponse expected =
-                new PathResponse(List.of(station1, station2, station3), 30, 1650);
+                new PathResponse(List.of(애플역, 갤럭시역, 옵티머스역), 30, 1650);
         // when
-        PathResponse actual = pathService.findShortestPath(station1_id, station3_id);
+        PathResponse actual = pathService.findShortestPath(애플역_id, 옵티머스역_id, 20);
 
         //then
         assertThat(actual)
@@ -63,14 +66,14 @@ public class PathServiceTest {
     @DisplayName("역 사이 경로가 존재하지 않을 때 예외를 발생시킨다.")
     void calculatePathNotExist() {
         // given
-        final Long station1_id = StationDaoImpl.getInstance().save(station1);
-        final Long station2_id = StationDaoImpl.getInstance().save(station2);
-        final Long station3_id = StationDaoImpl.getInstance().save(station3);
-        애플_갤럭시 = new Section(station1_id, station2_id, 100);
+        해외경유선 = new LineRequest("해외경유선", "blue", 애플역_id, 갤럭시역_id, 15, 400);
+        LineDaoImpl.getInstance().save(해외경유선);
+
+        애플_갤럭시 = new Section(애플역_id, 갤럭시역_id, 100);
         SectionDaoImpl.getInstance().save(애플_갤럭시);
 
         //when then
-        assertThatThrownBy(() -> pathService.findShortestPath(station1_id, station3_id))
+        assertThatThrownBy(() -> pathService.findShortestPath(애플역_id, 옵티머스역_id, 20))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("해당 역 사이 경로가 존재하지 않습니다.");
     }
@@ -78,13 +81,92 @@ public class PathServiceTest {
     @Test
     @DisplayName("요청에 해당 역이 존재하지 않을 때 예외를 발생시킨다.")
     void stationNotExistByRequest() {
-        // given
-        final Long station1_id = StationDaoImpl.getInstance().save(station1);
-        final Long station2_id = StationDaoImpl.getInstance().save(station2);
-
-        //when then
-        assertThatThrownBy(() -> pathService.findShortestPath(station1_id, station2_id + 1L))
+        // when then
+        assertThatThrownBy(() -> pathService.findShortestPath(애플역_id, 갤럭시역_id + 1L, 20))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("해당 역이 존재하지 않습니다.");
+                .hasMessage("해당 역 사이 경로가 존재하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("역 사이 최단 경로의 요금을 올바르게 계산한다.")
+    void calculateFareByShortestPath() {
+        // given
+        initLineAndSectionWithExtraFare();
+        final PathResponse expected =
+                new PathResponse(List.of(애플역, 갤럭시역, 옵티머스역), 25, 2150);
+        // when
+        PathResponse actual = pathService.findShortestPath(애플역_id, 옵티머스역_id, 19);
+
+        //then
+        assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("어린이가 이용할 경우의 역 사이 최단 경로 요금을 올바르게 계산한다.")
+    void calculateChildrenFareByShortestPath() {
+        // given
+        initLineAndSectionWithExtraFare();
+        final PathResponse expected =
+                new PathResponse(List.of(애플역, 갤럭시역, 옵티머스역), 25, 1250);
+        // when
+        PathResponse actual = pathService.findShortestPath(애플역_id, 옵티머스역_id, 6);
+
+        //then
+        assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+
+    @Test
+    @DisplayName("청소년이 이용할 경우의 역 사이 최단 경로 요금을 올바르게 계산한다.")
+    void calculateTeenagerFareByShortestPath() {
+        // given
+        initLineAndSectionWithExtraFare();
+        final PathResponse expected =
+                new PathResponse(List.of(애플역, 갤럭시역, 옵티머스역), 25, 1790);
+        // when
+        PathResponse actual = pathService.findShortestPath(애플역_id, 옵티머스역_id, 18);
+
+        //then
+        assertThat(actual)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    private void initLineAndSectionWithNotExtraFare() {
+        해외경유선 = new LineRequest("해외경유선", "blue", 애플역_id, 갤럭시역_id, 10, 0);
+        Long 해외경유선_id = LineDaoImpl.getInstance().save(해외경유선);
+        국내선 = new LineRequest("국내선", "red", 갤럭시역_id, 옵티머스역_id, 20, 0);
+        Long 국내선_id = LineDaoImpl.getInstance().save(국내선);
+
+        애플_갤럭시 = new Section(해외경유선_id, 애플역_id, 갤럭시역_id, 10);
+        SectionDaoImpl.getInstance().save(애플_갤럭시);
+        갤럭시_옵티머스 = new Section(국내선_id, 갤럭시역_id, 옵티머스역_id, 20);
+        SectionDaoImpl.getInstance().save(갤럭시_옵티머스);
+    }
+
+    private void initLineAndSectionWithExtraFare() {
+        해외경유선 = new LineRequest("해외경유선", "blue", 애플역_id, 갤럭시역_id, 15, 400);
+        Long 해외경유선_id = LineDaoImpl.getInstance().save(해외경유선);
+        국내선 = new LineRequest("국내선", "red", 갤럭시역_id, 옵티머스역_id, 10, 600);
+        Long 국내선_id = LineDaoImpl.getInstance().save(국내선);
+
+        애플_갤럭시 = new Section(해외경유선_id, 애플역_id, 갤럭시역_id, 15);
+        SectionDaoImpl.getInstance().save(애플_갤럭시);
+        갤럭시_옵티머스 = new Section(국내선_id, 갤럭시역_id, 옵티머스역_id, 10);
+        SectionDaoImpl.getInstance().save(갤럭시_옵티머스);
+    }
+
+    private void initStations() {
+        애플역 = new Station("애플역");
+        갤럭시역 = new Station("갤럭시역");
+        옵티머스역 = new Station("옵티머스역");
+
+        애플역_id = StationDaoImpl.getInstance().save(애플역);
+        갤럭시역_id = StationDaoImpl.getInstance().save(갤럭시역);
+        옵티머스역_id = StationDaoImpl.getInstance().save(옵티머스역);
     }
 }

--- a/src/test/java/wooteco/subway/service/PathServiceTest.java
+++ b/src/test/java/wooteco/subway/service/PathServiceTest.java
@@ -7,6 +7,7 @@ import wooteco.subway.domain.Line;
 import wooteco.subway.domain.Section;
 import wooteco.subway.domain.Station;
 import wooteco.subway.dto.LineRequest;
+import wooteco.subway.dto.PathRequest;
 import wooteco.subway.dto.PathResponse;
 import wooteco.subway.service.fakeDao.LineDaoImpl;
 import wooteco.subway.service.fakeDao.SectionDaoImpl;
@@ -54,7 +55,7 @@ public class PathServiceTest {
         final PathResponse expected =
                 new PathResponse(List.of(애플역, 갤럭시역, 옵티머스역), 30, 1650);
         // when
-        PathResponse actual = pathService.findShortestPath(애플역_id, 옵티머스역_id, 20);
+        PathResponse actual = pathService.findShortestPath(new PathRequest(애플역_id, 옵티머스역_id, 20));
 
         //then
         assertThat(actual)
@@ -73,7 +74,7 @@ public class PathServiceTest {
         SectionDaoImpl.getInstance().save(애플_갤럭시);
 
         //when then
-        assertThatThrownBy(() -> pathService.findShortestPath(애플역_id, 옵티머스역_id, 20))
+        assertThatThrownBy(() -> pathService.findShortestPath(new PathRequest(애플역_id, 옵티머스역_id, 20)))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("해당 역 사이 경로가 존재하지 않습니다.");
     }
@@ -82,7 +83,7 @@ public class PathServiceTest {
     @DisplayName("요청에 해당 역이 존재하지 않을 때 예외를 발생시킨다.")
     void stationNotExistByRequest() {
         // when then
-        assertThatThrownBy(() -> pathService.findShortestPath(애플역_id, 갤럭시역_id + 1L, 20))
+        assertThatThrownBy(() -> pathService.findShortestPath(new PathRequest(애플역_id, 갤럭시역_id + 1L, 20)))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("해당 역 사이 경로가 존재하지 않습니다.");
     }
@@ -95,7 +96,7 @@ public class PathServiceTest {
         final PathResponse expected =
                 new PathResponse(List.of(애플역, 갤럭시역, 옵티머스역), 25, 2150);
         // when
-        PathResponse actual = pathService.findShortestPath(애플역_id, 옵티머스역_id, 19);
+        PathResponse actual = pathService.findShortestPath(new PathRequest(애플역_id, 옵티머스역_id, 19));
 
         //then
         assertThat(actual)
@@ -111,7 +112,7 @@ public class PathServiceTest {
         final PathResponse expected =
                 new PathResponse(List.of(애플역, 갤럭시역, 옵티머스역), 25, 1250);
         // when
-        PathResponse actual = pathService.findShortestPath(애플역_id, 옵티머스역_id, 6);
+        PathResponse actual = pathService.findShortestPath(new PathRequest(애플역_id, 옵티머스역_id, 6));
 
         //then
         assertThat(actual)
@@ -128,7 +129,7 @@ public class PathServiceTest {
         final PathResponse expected =
                 new PathResponse(List.of(애플역, 갤럭시역, 옵티머스역), 25, 1790);
         // when
-        PathResponse actual = pathService.findShortestPath(애플역_id, 옵티머스역_id, 18);
+        PathResponse actual = pathService.findShortestPath(new PathRequest(애플역_id, 옵티머스역_id, 18));
 
         //then
         assertThat(actual)

--- a/src/test/java/wooteco/subway/service/fakeDao/LineDaoImpl.java
+++ b/src/test/java/wooteco/subway/service/fakeDao/LineDaoImpl.java
@@ -22,7 +22,7 @@ public class LineDaoImpl implements LineDao {
 
     @Override
     public Long save(LineRequest lineRequest) {
-        final Line line = new Line(lineRequest.getName(), lineRequest.getColor());
+        final Line line = new Line(lineRequest.getName(), lineRequest.getColor(), lineRequest.getExtraFare());
         Line persistLine = createNewObject(line);
         if (hasLine(persistLine.getName())) {
             throw new IllegalArgumentException("같은 이름의 노선이 존재합니다.");

--- a/src/test/java/wooteco/subway/service/fakeDao/LineDaoImpl.java
+++ b/src/test/java/wooteco/subway/service/fakeDao/LineDaoImpl.java
@@ -39,6 +39,16 @@ public class LineDaoImpl implements LineDao {
     }
 
     @Override
+    public List<Line> findByIds(List<Long> ids) {
+        final List<Line> lines = new ArrayList<>();
+        for (Long id : ids) {
+            lines.add(findById(id)
+                    .orElseThrow(() -> new IllegalArgumentException("해당하는 노선이 존재하지 않습니다.")));
+        }
+        return lines;
+    }
+
+    @Override
     public List<Line> findAll() {
         return lines;
     }


### PR DESCRIPTION
안녕하세요 앨런! 지난번에 피드백해주신 부분 2단계에 반영하여 제출합니다 :)
조금 웃길 수도 있지만, **요구사항에 청소년, 어린이 할인만 존재하여 6살 미만일 경우도 딱히 할인을 하지 않도록** 했습니다.

### 구조 설명
- `경로 중 추가요금이 있는 노선을 환승 하여 이용 할 경우 가장 높은 금액의 추가 요금만 적용` 요구사항으로 인해 `PathService`에서 `LineDao`를 추가로 상태로 가지게 됐습니다. 여기서 가장 높은 금액의 추가 요금을 가지는 Line을 찾습니다. 역시나 READ 작업 뿐이므로 `PathService`에서의 `readOnly` 설정은 유지하도록 했습니다.
- `jgrapht` 라이브러리 이용하는 부분의 구조가 변경됐습니다. `DefaultWeightedEdge`를 상속받는 `ShortestPathEdge` 도메인을 추가하여 최단경로에 포함된 노선들의 정보를 알 수 있도록 했습니다. 이 과정은 [4기 크루 후니가 올린 프롤로그](https://prolog.techcourse.co.kr/studylogs/2369)를 참고했습니다.
-  추가요금 정책과 나이에 따른 할인 정책 책임 분리를 위해 `AgeDiscountPolicy` enum 클래스를 만들어주었습니다.
- 나이 및 추가요금에 따른 정보 변경만 존재하므로 기존 테스트를 `@ParameterizedTest`를 이용하여 추가요금 및 나이에 따라서도 올바른 결과를 반환하는지 확인하게 했습니다.

추가된 요구사항 내용이 많지 않아 다행히 큰 변경 없이 금방 2단계를 제출할 수 있게 됐습니다!
다만, 고민이 되는 점은 `jgrapht`의 graph를 초기화해주는 작업이 `PathService`에서 꽤 많은 양을 차지한다는 점입니다. 이를 따로 분리해준다면 어떻게 분리해주는게 좋을지 고민되네요..

그 외에도 앨런이 보기에 부족한 점이 많이 보일 수 있을 것 같아요! 앨런의 피드백을 들으면서 리팩터링하고자 빠르게 미션을 제출해봅니다!
항상 감사합니다 😄 좋은 주말 보내세요!!